### PR TITLE
Fixed comfa model loading routine

### DIFF
--- a/comfa/comfa.cpp
+++ b/comfa/comfa.cpp
@@ -548,7 +548,7 @@ void fpredict(string modelfn, string predfn) {
 
     double intcpt;
     mdl >> intcpt;
-    double *beta = new double[nFpts];
+    double *beta = new double[nFpts * 2];
     
 //    for (int i = 0; i < 2 * nFpts; i++) mdl >> beta[i];
     for (int i = 0; i < 2 * nFpts; i++) {


### PR DESCRIPTION
Double array beta needs 2x nFpts as indicated in for statements ("i < 2 * nFpts") and will fail as is from illegal memory access during model load.  Fixed the array length from nFpts to nFpts * 2.  The compiled comfa now loads model normally (using option "comfa -pred pred.sdf -mkmodel false").